### PR TITLE
Disable debug logging to console

### DIFF
--- a/2_pvc_destination_gen/extras/container/entrypoint.sh
+++ b/2_pvc_destination_gen/extras/container/entrypoint.sh
@@ -26,4 +26,4 @@ mv /etc/ssh/moduli /opt/ssh
 sed -i "s/UsePAM yes/UsePAM no/" /opt/ssh/sshd_config
 chown -R ssh:ssh /opt/ssh
 
-exec /usr/sbin/sshd -De -f /opt/ssh/sshd_config
+exec /usr/sbin/sshd -D -f /opt/ssh/sshd_config


### PR DESCRIPTION
I confirmed this noise is from the health check. It looks like you can change the interval to 300s but not completely disable it.

```
kex_exchange_identification: Connection closed by remote host
WARNING: 'UsePAM no' is not supported in Fedora and may cause several problems.
```
Removing -e hides the debug logs and just gives us the standard information from the service. 
```
$ oc logs -f test-2-7z2c6
ssh-keygen: generating new host keys: RSA DSA ECDSA ED25519 
WARNING: 'UsePAM no' is not supported in Fedora and may cause several problems.
```