### PR TITLE
Phase 1 changes to accomodate more efficient processing

### DIFF
--- a/1_pvc_data_gen/pvc_data_gen.py
+++ b/1_pvc_data_gen/pvc_data_gen.py
@@ -63,6 +63,7 @@ for namespace in data['namespaces_to_migrate']:
 
     v1_pvcs = dyn_client.resources.get(api_version='v1', kind='PersistentVolumeClaim')
     pvc_list = v1_pvcs.get(namespace=namespace)
+    namespaced_pvcs = []
     for pvc in pvc_list.items:
         
         # Map pod binding and uid onto PVC data
@@ -142,7 +143,12 @@ for namespace in data['namespaces_to_migrate']:
                 'bound_pod_mount_path': boundPodMountPath,
                 'bound_pod_mount_container_name': boundPodMountContainerName
         }
-        output.append(pvc_out)
+        namespaced_pvcs.append(pvc_out)
+    output_entry = {
+            'namespace': namespace,
+            'pvcs': namespaced_pvcs
+    }
+    output.append(output_entry)
     
 
 # Write out results to pvc-data.json, node-list.json


### PR DESCRIPTION
After phase 1 changes:
```
[
    {
        "pvcs": [
            {
                "bound_pod_name": "rocketchat-db-1-gh6q5", 
                "labels": {}, 
                "pvc_uid": "92c149e8-b79b-11ea-aee6-0e070408f2bb", 
                "bound": "Bound", 
                "pvc_namespace": "rocket-chat", 
                "access_modes": [
                    "ReadWriteOnce"
                ], 
                "capacity": "10Gi", 
                "bound_pod_mount_container_name": "rocketchat-db", 
                "bound_pod_mount_path": "/data/db", 
                "bound_pod_uid": "95a033e6-b79b-11ea-aee6-0e070408f2bb", 
                "node_name": "node3.dymurray-ocp3.internal", 
                "storage_class": "glusterfs-storage", 
                "annotations": {
                    "pv.kubernetes.io/bound-by-controller": "yes", 
                    "volume.beta.kubernetes.io/storage-provisioner": "kubernetes.io/glusterfs", 
                    "pv.kubernetes.io/bind-completed": "yes"
                }, 
                "volume_name": "pvc-92c149e8-b79b-11ea-aee6-0e070408f2bb", 
                "pvc_name": "rocketchat-data-claim"
            }
        ], 
        "namespace": "rocket-chat"
    }
]
```