### PR TITLE
skip waiting for deleted service

### DIFF
--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -127,6 +127,7 @@
   until: "{{ s.resources | length == 0 }}"
   retries: "{{ transfer_svc_delete_wait_retries }}"
   delay: 3
+  when: "{{ wait_for_finalizer }}"
 
 - name: "Printing failed / succeded pvcs"
   debug:

--- a/3_run_rsync/vars/run-rsync.yml
+++ b/3_run_rsync/vars/run-rsync.yml
@@ -10,3 +10,4 @@ successful_pvcs_dir: ../output/
 mig_dest_ssh_user: root
 mig_dest_ssh_public_key: ""
 mig_dest_ssh_private_key: "" # path to private key used for transfer pod
+wait_for_finalizer: false


### PR DESCRIPTION
With limited LB, the assumption is, finalizers will keep deleting the
resource in the background. If enough resources are not available
the next service creation will wait for the right status. 

This will save the wait time and introduce some parallelization at
service creation and deletion and is safe with the assumption