### PR TITLE
Add KUBECONFIG logged in version check

### DIFF
--- a/1_pvc_data_gen/pvc_data_gen.py
+++ b/1_pvc_data_gen/pvc_data_gen.py
@@ -21,13 +21,11 @@ except:
 try:
     kube_minor_version = dyn_client.version.get("kubernetes", {}).get("minor", "").split("+")[0]
     if int(kube_minor_version) > 11:
-        print("[!] [WARNING] KUBECONFIG should be set to OCP 3.x cluster for 'Stage 1', but OCP 4.x cluster detected.")
+        print("\n[!] [WARNING] KUBECONFIG should be set to source cluster (likely OCP 3.x) for 'Stage 1', but OCP 4.x cluster detected.")
         print("[!] [WARNING] Detected k8s version: {}\n".format(dyn_client.version.get("kubernetes", {}).get("gitVersion", "")))
-        selection = input("[?] Press 'Enter' to quit, or type 'i' to ignore and continue: ")
-        if 'i' in selection:
-            print("Continuing...\n")
-        else:
-            print("Exiting...\n")
+        selection = input("[?] Press 'Enter' to quit, or type 'i' to ignore warning: ")
+        if 'i' not in selection:
+            print("Exiting...")
             os._exit(1)
 except:
     print("[!] Failed to parse OpenShift version.")
@@ -59,7 +57,7 @@ for namespace in data['namespaces_to_migrate']:
         ns_out = {'namespace': namespace, 'annotations': ns.metadata.get("annotations", emptyDict).__dict__}
         output.append(ns_out)
     except:
-        print("\n[!] v1/namespace not found: " + namespace)
+        print("\n[WARNING] v1/namespace not found: {}\n".format(namespace))
     
 ns_data_file = os.path.join(output_dir, 'namespace-data.json')
 with open(ns_data_file, 'w') as f:
@@ -104,8 +102,6 @@ for namespace in data['namespaces_to_migrate']:
                                 boundPodMountPath = vol_mount.get("mountPath", "")
                                 boundPodMountContainerName = container.get('name', "")
                                 break
-
-
                     break
             if pvc_pod != None:
                 break

--- a/1_pvc_data_gen/pvc_data_gen.py
+++ b/1_pvc_data_gen/pvc_data_gen.py
@@ -2,7 +2,6 @@ import json
 import yaml
 import urllib3
 import os
-import re
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 from kubernetes import client, config


### PR DESCRIPTION
- [x] Add KUBECONFIG src cluster check to stage 1
- [ ] Add KUBECONFIG dest cluster check to stage 2 (will be in follow-up PR)
- [ ] Add KUBECONFIG dest cluster check to stage 3 (will be in follow-up PR)

---

**For stages 2 and 3, thinking changes will look like:**
1. Check version endpoint for k8s minorVersion > `11` (this is the cutoff between OCP 3.x and 4.x), exit early with clear message to user  if we find we're on the wrong OCP version. Let user configure an override version in ansible vars `override_ocp_version_check`
2. After good version verified, make copy of KUBECONFIG to "known good KUBECONFIG path"
3. For all issued `oc` commands and ansible `k8s` module invocations, use this "known good KUBECONFIG path" in `oc --kubeconfig` calls and `k8s` tasks
