### PR TITLE
Parallel RSync support (one namespace at a time)

### DIFF
--- a/3_run_rsync/README.md
+++ b/3_run_rsync/README.md
@@ -26,6 +26,10 @@ transfer_pod_mem_requests: '1Gi'
 mig_dest_ssh_public_key: ""  # path to public key to install as authorized user in transfer pod
 mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transfer pod as 'root' user
 
+# Rsync Options
+rsync_timeout: 7200  # time in seconds, default 1 hour
+rsync_batch_size: 10 # how many rsync jobs should run in parallel
+
 # Wait for transfer pod service ELB deletion to complete before proceeding to next PVC
 wait_for_finalizer: false
 ```

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -88,6 +88,7 @@
     failed_pvcs: []
     successful_pvcs: []
 
+
 - name: "Run parallel rsync jobs for PVCs in {{ pvc_namespace }}"
   include_tasks: "tasks/rsync.yml"
   loop: "{{ pvcs | batch(rsync_batch_size) | list }}"

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -110,26 +110,30 @@
   retries: "{{ transfer_pod_delete_wait_retries }}"
   delay: 3
 
-# - name: "Cleanup the service for rsync"
-#   k8s:
-#     state: absent
-#     definition: "{{ lookup('template', 'svc.yml.j2') }}"
+- name: "Cleanup the service for rsync"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'svc.yml.j2') }}"
 
-# - name: "Wait for service to be deleted"
-#   k8s_info:
-#     api_version: v1
-#     kind: service
-#     name: "{{ svc_name }}"
-#     namespace: "{{ pvc_namespace }}"
-#   register: s
-#   until: "{{ s.resources | length == 0 }}"
-#   retries: "{{ transfer_svc_delete_wait_retries }}"
-#   delay: 3
-#   when: "{{ wait_for_finalizer }}"
+- name: "Wait for service to be deleted"
+  k8s_info:
+    api_version: v1
+    kind: service
+    name: "{{ svc_name }}"
+    namespace: "{{ pvc_namespace }}"
+  register: s
+  until: "{{ s.resources | length == 0 }}"
+  retries: "{{ transfer_svc_delete_wait_retries }}"
+  delay: 3
+  when: "{{ wait_for_finalizer }}"
 
-- name: "Printing failed / successful PVC rsync jobs"
+- name: "Printing successful / failed PVC rsync jobs"
   debug:
-    msg: "Failed: {{ failed_pvcs }} \nSuccessful:{{ successful_pvcs }}"
+    msg: "Successful PVCs: {{ successful_pvcs }} | Failed PVCs: {{ failed_pvcs }}"
+
+- name: "Print counts of successful / failed PVCs"
+  debug: 
+    msg: "# Successful PVCs: {{ successful_pvcs|length }} | # Failed PVCs: {{ failed_pvcs|length }}"
 
 - name: "Dumping failure report"
   copy:

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -88,15 +88,8 @@
     failed_pvcs: []
     successful_pvcs: []
 
-- name: "Run rsync for pvc synchronously"
-  vars:
-    pvc_ns: "{{ item.pvc_namespace }}"
-    pvc_name: "{{ item.pvc_name }}"
-    volume_name: "{{ item.volume_name }}"
-    bound_pod_uid: "{{ item.bound_pod_uid }}"
-    node_name: "{{ item.node_name }}"
+- name: "Run parallel rsync jobs for PVCs in {{ pvc_namespace }}"
   include_tasks: "tasks/rsync.yml"
-  with_items: "{{ pvcs }}"
 
 - name: "Cleanup the transfer pod for rsync"
   k8s:
@@ -114,26 +107,26 @@
   retries: "{{ transfer_pod_delete_wait_retries }}"
   delay: 3
 
-- name: "Cleanup the service for rsync"
-  k8s:
-    state: absent
-    definition: "{{ lookup('template', 'svc.yml.j2') }}"
+# - name: "Cleanup the service for rsync"
+#   k8s:
+#     state: absent
+#     definition: "{{ lookup('template', 'svc.yml.j2') }}"
 
-- name: "Wait for service to be deleted"
-  k8s_info:
-    api_version: v1
-    kind: service
-    name: "{{ svc_name }}"
-    namespace: "{{ pvc_namespace }}"
-  register: s
-  until: "{{ s.resources | length == 0 }}"
-  retries: "{{ transfer_svc_delete_wait_retries }}"
-  delay: 3
-  when: "{{ wait_for_finalizer }}"
+# - name: "Wait for service to be deleted"
+#   k8s_info:
+#     api_version: v1
+#     kind: service
+#     name: "{{ svc_name }}"
+#     namespace: "{{ pvc_namespace }}"
+#   register: s
+#   until: "{{ s.resources | length == 0 }}"
+#   retries: "{{ transfer_svc_delete_wait_retries }}"
+#   delay: 3
+#   when: "{{ wait_for_finalizer }}"
 
-- name: "Printing failed / succeded pvcs"
+- name: "Printing failed / successful PVC rsync jobs"
   debug:
-    msg: "{{ failed_pvcs }} {{ successful_pvcs }}"
+    msg: "Failed: {{ failed_pvcs }} \nSuccessful:{{ successful_pvcs }}"
 
 - name: "Dumping failure report"
   copy:

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -90,6 +90,9 @@
 
 - name: "Run parallel rsync jobs for PVCs in {{ pvc_namespace }}"
   include_tasks: "tasks/rsync.yml"
+  loop: "{{ pvcs | batch(rsync_batch_size) | list }}"
+  loop_control:
+    loop_var: "pvc_batch"
 
 - name: "Cleanup the transfer pod for rsync"
   k8s:

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -52,7 +52,7 @@
   retries: 100
   delay: 3
   with_items: "{{ pvc_batch }}"
-
+  
 - name: "Synchronizing files. This may take a while... [rsync_batch_size={{ rsync_batch_size }}] "
   async: "{{ rsync_timeout }}"
   register: async_results
@@ -111,6 +111,9 @@
     successful_pvc:
       - name: "{{ item.item.item.pvc_name}}"
         namespace: "{{ item.item.item.pvc_namespace }}"
+        stdout: "{{ item.stdout }}"
+        stderr: "{{ item.stderr }}"
+        rc: "{{ item.rc }}"
   set_fact:
     successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
   when: item.rc == 0

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -24,7 +24,7 @@
     state: directory
   ignore_errors: true
   become: yes
-  with_items: "{{ pvcs }}"
+  with_items: "{{ pvc_batch }}"
   
 
 - name: "Copying private key to source node"
@@ -37,7 +37,7 @@
     mode: 0600
   ignore_errors: true
   become: yes
-  with_items: "{{ pvcs }}"
+  with_items: "{{ pvc_batch }}"
   
 
 - name: "Wait for dns"
@@ -51,7 +51,7 @@
   until: dig_output.rc == 0
   retries: 100
   delay: 3
-  with_items: "{{ pvcs }}"
+  with_items: "{{ pvc_batch }}"
 
 - name: "Synchronizing files. This may take a while..."
   async: "{{ rsync_timeout }}"
@@ -66,7 +66,7 @@
   shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p 2222 -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
   ignore_errors: true
   become: yes
-  with_items: "{{ pvcs }}"
+  with_items: "{{ pvc_batch }}"
 
 - name: Wait for rsync jobs to finish
   vars: 
@@ -90,7 +90,7 @@
     state: absent
   ignore_errors: true
   become: yes
-  with_items: "{{ pvcs }}"
+  with_items: "{{ pvc_batch }}"
 
 # End tasks delegated to source node 
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -12,69 +12,105 @@
 - set_fact:
     mig_source_data_base_location: "/var/lib/origin/openshift.local.volumes"
     mig_source_data_location_k8s_mount: "kubernetes.io~glusterfs"
-
-- set_fact:
-    mig_dest_service_url: "{{ svc.resources[0].status.loadBalancer.ingress[0].hostname }}"
-    mig_dest_data_location: "/mnt/{{ pvc_ns }}/{{ pvc_name }}"
-    mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ volume_name }}/"
-    mig_source_host: "{{ node_name }}"
     mig_dest_ssh_key_remote_location: "~/.ssh/dest_key"
-
-- delegate_to: "{{ mig_source_host|mandatory }}"
+    
+# Start tasks delegated to source node
+- name: "Ensure .ssh directory on source node"
+  vars:
+    mig_source_host: "{{ item.node_name }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  file:
+    path: "~/.ssh"
+    state: directory
   ignore_errors: true
-  tags:
-  - sync_phase
-  - final_phase
-  block:
-  - name: "Ensure .ssh directory on source node"
-    file:
-      path: "~/.ssh"
-      state: directory
-    become: yes
+  become: yes
+  with_items: "{{ pvcs }}"
+  
 
-  - name: "Copying private key to source node"
-    copy:
-      src: "{{ mig_dest_ssh_private_key|mandatory }}"
-      dest: "{{ mig_dest_ssh_key_remote_location }}"
-      mode: 0600
-    become: yes
-
-  - name: "Wait for dns"
-    shell: "nslookup {{ mig_dest_service_url }}"
-    register: dig_output
-    until: dig_output.rc == 0
-    retries: 100
-    delay: 3
-
-  - name: "Synchronizing files. This may take a while..."
-    shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p 2222 -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
-
-    register: sync_output
-    become: yes
-
-  - name: "Removing private key from source node"
-    file:
-      path: "{{ mig_dest_ssh_key_remote_location }}"
-      state: absent
-    become: yes
-
-- name: "Collect failed pvcs"
+- name: "Copying private key to source node"
   vars:
-    failed_pvc:
-      - name: "{{ pvc_name }}"
-        namespace: "{{ pvc_ns }}"
-        stdout: "{{ sync_output.stdout }}"
-        stderr: "{{ sync_output.stderr }}"
-        rc: "{{ sync_output.rc }}"
-  set_fact:
-    failed_pvcs: "{{ failed_pvcs +  failed_pvc }}"
-  when: sync_output.rc != 0
+    mig_source_host: "{{ item.node_name }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  copy:
+    src: "{{ mig_dest_ssh_private_key|mandatory }}"
+    dest: "{{ mig_dest_ssh_key_remote_location }}"
+    mode: 0600
+  ignore_errors: true
+  become: yes
+  with_items: "{{ pvcs }}"
+  
 
-- name: "Collect successful pvcs"
+- name: "Wait for dns"
   vars:
-    successful_pvc:
-      - name: "{{ pvc_name }}"
-        namespace: "{{ pvc_ns }}"
-  set_fact:
-    successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
-  when: sync_output.rc == 0
+    mig_source_host: "{{ item.node_name }}"
+    mig_dest_service_url: "{{ svc.resources[0].status.loadBalancer.ingress[0].hostname }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  shell: "nslookup {{ mig_dest_service_url }}"
+  ignore_errors: true
+  register: dig_output
+  until: dig_output.rc == 0
+  retries: 100
+  delay: 3
+  with_items: "{{ pvcs }}"
+
+- name: "Synchronizing files. This may take a while..."
+  async: "{{ rsync_timeout }}"
+  register: async_results
+  poll: 0
+  vars:
+    mig_source_host: "{{ item.node_name }}"
+    mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ item.bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ item.volume_name }}/"
+    mig_dest_service_url: "{{ svc.resources[0].status.loadBalancer.ingress[0].hostname }}"
+    mig_dest_data_location: "/mnt/{{ item.pvc_namespace }}/{{ item.pvc_name }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p 2222 -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
+  ignore_errors: true
+  become: yes
+  with_items: "{{ pvcs }}"
+
+- name: Wait for rsync jobs to finish
+  vars: 
+    mig_source_host: "{{ item.item.node_name }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  async_status: 
+    jid: "{{ item.ansible_job_id }}"
+  register: result
+  until: result.finished
+  retries: "{{ (rsync_timeout|int / 5) | int}}"
+  delay: 5
+  become: yes
+  with_items: "{{ async_results.results }}"
+
+- name: "Removing private key from source node"
+  vars:
+    mig_source_host: "{{ item.node_name }}"
+  delegate_to: "{{ mig_source_host|mandatory }}"
+  file:
+    path: "{{ mig_dest_ssh_key_remote_location }}"
+    state: absent
+  ignore_errors: true
+  become: yes
+  with_items: "{{ pvcs }}"
+
+# End tasks delegated to source node 
+
+# - name: "Collect failed pvcs"
+#   vars:
+#     failed_pvc:
+#       - name: "{{ pvc_name }}"
+#         namespace: "{{ item.pvc_namespace }}"
+#         stdout: "{{ sync_output.stdout }}"
+#         stderr: "{{ sync_output.stderr }}"
+#         rc: "{{ sync_output.rc }}"
+#   set_fact:
+#     failed_pvcs: "{{ failed_pvcs +  failed_pvc }}"
+#   when: sync_output.rc != 0
+
+# - name: "Collect successful pvcs"
+#   vars:
+#     successful_pvc:
+#       - name: "{{ pvc_name }}"
+#         namespace: "{{ item.pvc_namespace }}"
+#   set_fact:
+#     successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
+#   when: sync_output.rc == 0

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -40,7 +40,7 @@
   with_items: "{{ pvc_batch }}"
   
 
-- name: "Wait for dns"
+- name: "Wait for load balancer DNS entry"
   vars:
     mig_source_host: "{{ item.node_name }}"
     mig_dest_service_url: "{{ svc.resources[0].status.loadBalancer.ingress[0].hostname }}"
@@ -53,7 +53,7 @@
   delay: 3
   with_items: "{{ pvc_batch }}"
 
-- name: "Synchronizing files. This may take a while..."
+- name: "Synchronizing files. This may take a while... [rsync_batch_size={{ rsync_batch_size }}] "
   async: "{{ rsync_timeout }}"
   register: async_results
   poll: 0
@@ -68,14 +68,14 @@
   become: yes
   with_items: "{{ pvc_batch }}"
 
-- name: Wait for rsync jobs to finish
+- name: "Wait for rsync jobs to finish [rsync_timeout={{ rsync_timeout }}]"
   vars: 
     mig_source_host: "{{ item.item.node_name }}"
   delegate_to: "{{ mig_source_host|mandatory }}"
   async_status: 
     jid: "{{ item.ansible_job_id }}"
-  register: result
-  until: result.finished
+  register: status_result
+  until: status_result.finished
   retries: "{{ (rsync_timeout|int / 5) | int}}"
   delay: 5
   become: yes
@@ -91,26 +91,27 @@
   ignore_errors: true
   become: yes
   with_items: "{{ pvc_batch }}"
-
 # End tasks delegated to source node 
 
-# - name: "Collect failed pvcs"
-#   vars:
-#     failed_pvc:
-#       - name: "{{ pvc_name }}"
-#         namespace: "{{ item.pvc_namespace }}"
-#         stdout: "{{ sync_output.stdout }}"
-#         stderr: "{{ sync_output.stderr }}"
-#         rc: "{{ sync_output.rc }}"
-#   set_fact:
-#     failed_pvcs: "{{ failed_pvcs +  failed_pvc }}"
-#   when: sync_output.rc != 0
+- name: "Collect list of failed PVCs from batch"
+  vars:
+    failed_pvc:
+      - name: "{{ item.item.item.pvc_name}}"
+        namespace: "{{ item.item.item.pvc_namespace }}"
+        stdout: "{{ item.stdout }}"
+        stderr: "{{ item.stderr }}"
+        rc: "{{ item.rc }}"
+  set_fact:
+    failed_pvcs: "{{ failed_pvcs +  failed_pvc }}"
+  when: item.rc != 0
+  with_items: "{{ status_result.results }}"
 
-# - name: "Collect successful pvcs"
-#   vars:
-#     successful_pvc:
-#       - name: "{{ pvc_name }}"
-#         namespace: "{{ item.pvc_namespace }}"
-#   set_fact:
-#     successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
-#   when: sync_output.rc == 0
+- name: "Collect list of successful PVCs from batch"
+  vars:
+    successful_pvc:
+      - name: "{{ item.item.item.pvc_name}}"
+        namespace: "{{ item.item.item.pvc_namespace }}"
+  set_fact:
+    successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
+  when: item.rc == 0
+  with_items: "{{ status_result.results }}"

--- a/3_run_rsync/vars/run-rsync.yml.example
+++ b/3_run_rsync/vars/run-rsync.yml.example
@@ -8,5 +8,8 @@ transfer_pod_mem_requests: '1Gi'
 mig_dest_ssh_public_key: ""  # path to public key to install as authorized user in transfer pod
 mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transfer pod as 'root' user
 
+# Seconds to wait for async rsync job to finish
+rsync_timeout: 7200
+
 # Wait for transfer pod service ELB deletion to complete before proceeding to next PVC
 wait_for_finalizer: false

--- a/3_run_rsync/vars/run-rsync.yml.example
+++ b/3_run_rsync/vars/run-rsync.yml.example
@@ -9,7 +9,7 @@ mig_dest_ssh_public_key: ""  # path to public key to install as authorized user 
 mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transfer pod as 'root' user
 
 # Rsync Options
-rsync_timeout: 7200  # time in seconds, default 1 hour
+rsync_timeout: 7200  # time in seconds, default 2 hours
 rsync_batch_size: 10 # how many rsync jobs should run in parallel
 
 # Wait for transfer pod service ELB deletion to complete before proceeding to next PVC

--- a/3_run_rsync/vars/run-rsync.yml.example
+++ b/3_run_rsync/vars/run-rsync.yml.example
@@ -8,8 +8,9 @@ transfer_pod_mem_requests: '1Gi'
 mig_dest_ssh_public_key: ""  # path to public key to install as authorized user in transfer pod
 mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transfer pod as 'root' user
 
-# Seconds to wait for async rsync job to finish
-rsync_timeout: 7200
+# Rsync Options
+rsync_timeout: 7200  # time in seconds, default 1 hour
+rsync_batch_size: 10 # how many rsync jobs should run in parallel
 
 # Wait for transfer pod service ELB deletion to complete before proceeding to next PVC
 wait_for_finalizer: false


### PR DESCRIPTION
- [x] Launch all rsync jobs for a namespace in parallel and wait for them to return
- [x] Add variable size batching
- [x] Fix success/error reporting to work with async output


**Stage 3 Vars Updates**
```
# Rsync Options
rsync_timeout: 7200  # time in seconds, default 2 hours
rsync_batch_size: 10 # how many rsync jobs should run in parallel
```

**Sample Output**
```
TASK [Synchronizing files. This may take a while... [rsync_batch_size=2]]**********************************************************************************************************************

changed: [localhost -> node3.ci-cam-demo-311.internal] => (item={'pvc_name': 'nginx-html', 'pvc_namespace': 'dwhatley-nginx-pv', 'capacity': '50Mi', 'labels': {'app': 'nginx'}, 'annotations': {'pv.kubernetes.io/bind-completed': 'yes', 'pv.kubernetes.io/bound-by-controller': 'yes', 'volume.beta.kubernetes.io/storage-provisioner': 'kubernetes.io/glusterfs'}, 'pvc_uid': '69e5196c-ba14-11ea-91f7-16034a941f37', 'storage_class': 'glusterfs-storage', 'bound': 'Bound', 'access_modes': ['ReadWriteOnce'], 'node_name': 'node3.ci-cam-demo-311.internal', 'volume_name': 'pvc-69e5196c-ba14-11ea-91f7-16034a941f37', 'bound_pod_name': 'nginx-deployment-557dd97bf8-fv95x', 'bound_pod_uid': '6a30faad-ba14-11ea-91f7-16034a941f37', 'bound_pod_mount_path': '/usr/share/nginx/html', 'bound_pod_mount_container_name': 'nginx'})
changed: [localhost -> node3.ci-cam-demo-311.internal] => (item={'pvc_name': 'nginx-logs', 'pvc_namespace': 'dwhatley-nginx-pv', 'capacity': '1Mi', 'labels': {'app': 'nginx'}, 'annotations': {'pv.kubernetes.io/bind-completed': 'yes', 'pv.kubernetes.io/bound-by-controller': 'yes', 'volume.beta.kubernetes.io/storage-provisioner': 'kubernetes.io/glusterfs'}, 'pvc_uid': '69d20e8b-ba14-11ea-91f7-16034a941f37', 'storage_class': 'glusterfs-storage', 'bound': 'Bound', 'access_modes': ['ReadWriteOnce'], 'node_name': 'node3.ci-cam-demo-311.internal', 'volume_name': 'pvc-69d20e8b-ba14-11ea-91f7-16034a941f37', 'bound_pod_name': 'nginx-deployment-557dd97bf8-fv95x', 'bound_pod_uid': '6a30faad-ba14-11ea-91f7-16034a941f37', 'bound_pod_mount_path': '/var/log/nginx', 'bound_pod_mount_container_name': 'nginx'})

TASK [Wait for rsync jobs to finish [rsync_timeout=7200]] **************************************************************************************************************************************

changed: [localhost -> node3.ci-cam-demo-311.internal] => (item={'started': 1, 'finished': 0, 'results_file': '/root/.ansible_async/399873044716.46624', 'ansible_job_id': '399873044716.46624', 'changed': True, 'failed': False, 'item': {'pvc_name': 'nginx-html', 'pvc_namespace': 'dwhatley-nginx-pv', 'capacity': '50Mi', 'labels': {'app': 'nginx'}, 'annotations': {'pv.kubernetes.io/bind-completed': 'yes', 'pv.kubernetes.io/bound-by-controller': 'yes', 'volume.beta.kubernetes.io/storage-provisioner': 'kubernetes.io/glusterfs'}, 'pvc_uid': '69e5196c-ba14-11ea-91f7-16034a941f37', 'storage_class': 'glusterfs-storage', 'bound': 'Bound', 'access_modes': ['ReadWriteOnce'], 'node_name': 'node3.ci-cam-demo-311.internal', 'volume_name': 'pvc-69e5196c-ba14-11ea-91f7-16034a941f37', 'bound_pod_name': 'nginx-deployment-557dd97bf8-fv95x', 'bound_pod_uid': '6a30faad-ba14-11ea-91f7-16034a941f37', 'bound_pod_mount_path': '/usr/share/nginx/html', 'bound_pod_mount_container_name': 'nginx'}, 'ansible_loop_var': 'item'})
changed: [localhost -> node3.ci-cam-demo-311.internal] => (item={'started': 1, 'finished': 0, 'results_file': '/root/.ansible_async/84264552119.46726', 'ansible_job_id': '84264552119.46726', 'changed': True, 'failed': False, 'item': {'pvc_name': 'nginx-logs', 'pvc_namespace': 'dwhatley-nginx-pv', 'capacity': '1Mi', 'labels': {'app': 'nginx'}, 'annotations': {'pv.kubernetes.io/bind-completed': 'yes', 'pv.kubernetes.io/bound-by-controller': 'yes', 'volume.beta.kubernetes.io/storage-provisioner': 'kubernetes.io/glusterfs'}, 'pvc_uid': '69d20e8b-ba14-11ea-91f7-16034a941f37', 'storage_class': 'glusterfs-storage', 'bound': 'Bound', 'access_modes': ['ReadWriteOnce'], 'node_name': 'node3.ci-cam-demo-311.internal', 'volume_name': 'pvc-69d20e8b-ba14-11ea-91f7-16034a941f37', 'bound_pod_name': 'nginx-deployment-557dd97bf8-fv95x', 'bound_pod_uid': '6a30faad-ba14-11ea-91f7-16034a941f37', 'bound_pod_mount_path': '/var/log/nginx', 'bound_pod_mount_container_name': 'nginx'}, 'ansible_loop_var': 'item'})
```