### PR TITLE
Check if PV directory to be migrated exists on the source cluster

### DIFF
--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -46,9 +46,19 @@
     retries: 100
     delay: 3
 
+  - name: "Ensure directory exists on the source"
+    stat:
+      path: "{{ mig_source_data_location }}"
+    register: source_dir_stat
+
+  - when: not source_dir_stat.stat.exists
+    fail:
+      msg: |
+        The directory {{ mig_source_data_location }} does not exist on the source cluster.
+        Skipping to the next PV...
+
   - name: "Synchronizing files. This may take a while..."
     shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p 2222 -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
-
     register: sync_output
     become: yes
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -78,7 +78,8 @@
         rc: "{{ sync_output.rc }}"
   set_fact:
     failed_pvcs: "{{ failed_pvcs +  failed_pvc }}"
-  when: sync_output.rc != 0
+  when: sync_output is not defined or 
+    sync_output.rc != 0
 
 - name: "Collect successful pvcs"
   vars:
@@ -87,4 +88,6 @@
         namespace: "{{ pvc_ns }}"
   set_fact:
     successful_pvcs: "{{ successful_pvcs +  successful_pvc }}"
-  when: sync_output.rc == 0
+  when:
+    - sync_output is defined 
+    - sync_output.rc == 0


### PR DESCRIPTION
- adds new check to ensure directory exists on the source cluster 
- fixes success/failure result collection logic for cases where Rsync step is never reached

Fixes #90 