### PR TITLE
fix wait for pod to be running

### DIFF
--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -64,12 +64,12 @@
     name: "{{ pod_name }}"
     namespace: "{{ pvc_namespace }}"
   register: pod
-  until: "true in (pod | json_query('resources[].status.containerStatuses[].ready'))"
+  until: "'Running' in (pod | json_query('resources[].status.phase'))"
   retries: "{{ transfer_pod_wait_retries }}"
   delay: 3
 
 - name: "Wait for svc to get a load balancer hostname"
-  k8s_facts:
+  k8s_info:
     api_version: v1
     kind: service
     name: "{{ svc_name }}"


### PR DESCRIPTION
Since we have two containers, if one container is "Ready"
and other is causing the pod to crashloop, wait task was not
blocking long enough for both containers to be ready. This
uses the pod phase "Running" which should wait for all the
containers to be ready