### PR TITLE
fixes missing variable and the volume directory check logic

### DIFF
--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -95,6 +95,7 @@
     volume_name: "{{ item.volume_name }}"
     bound_pod_uid: "{{ item.bound_pod_uid }}"
     node_name: "{{ item.node_name }}"
+    pvc_vol_safe_name: "{{ item.pvc_vol_safe_name }}"
   include_tasks: "tasks/rsync.yml"
   with_items: "{{ pvcs }}"
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -50,8 +50,9 @@
     stat:
       path: "{{ mig_source_data_location }}"
     register: source_dir_stat
+    become: yes
 
-  - when: not source_dir_stat.stat.exists
+  - when: not source_dir_stat.get('stat', {}).get('exists', False)
     fail:
       msg: |
         The directory {{ mig_source_data_location }} does not exist on the source cluster.


### PR DESCRIPTION
Fixes two previous PRs :
- Checking whether folder exists on the source side - needed to be run as sudo
- `pvc_vol_safe_name` needed to be  passed to the template inside loop control