### PR TITLE
Updated warning message

### DIFF
--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -55,7 +55,10 @@
   - when: not source_dir_stat.get('stat', {}).get('exists', False)
     fail:
       msg: |
-        The directory {{ mig_source_data_location }} does not exist on the source cluster.
+        The directory {{ mig_source_data_location }} does not exist on the source cluster. Possible reasons could be :
+        [1] PVC is not bound to any pod
+        [2] Backing storage is not readable
+        [3] State of the source system changed between Stage 1 and Stage 3 execution
         Skipping to the next PV...
 
   - name: "Synchronizing files. This may take a while..."


### PR DESCRIPTION
Fixes #39 

The location of the mounted PVC on the source side is constructed using the `bound_pod_uid` field. If the PVC is not mounted on any pod, the check for source side location would fail. 