### PR TITLE
New instructions for mig-agnosticd users

### DIFF
--- a/docs/inventory-notes.md
+++ b/docs/inventory-notes.md
@@ -28,6 +28,8 @@ Therefore, `pvc-migrate` needs to be able to connect with every node on the sour
 - Set SSH config (~/.ssh/config) on the host where `ansible-playbook` will be invoked
 - Set Ansible config (ansible.cfg) on the host where `ansible-playbook` will be invoked
 
+**Note** : For development clusters installed using `mig-agnosticd`, please follow the SSH instructions given [here](https://github.com/konveyor/mig-agnosticd/blob/master/3.x/SSH-GUIDE.md)
+
 ### **Mode 1**: Running 'ansible-playbook' on Bastion
 
 ```


### PR DESCRIPTION
For mig-agnosticd cluster installations, creating SSH configuration for pvc-migrate is an easy process where the users just have to link two SSH configurations exported post cluster installation in their main SSH config file. 

This PR updates the instructions for mig-agnosticd users.