### PR TITLE
Allow rsync transfer options via variable

### DIFF
--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -131,7 +131,7 @@
     - name: "Synchronizing files. This may take a while..."
       environment:
         RSYNC_PASSWORD: "{{ rsync_password }}"
-      shell: "rsync {{ rsync_opts }} {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
+      shell: "rsync {{ rsync_opts }} --port 2222 {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
       register: sync_output
       become: yes
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -131,7 +131,7 @@
     - name: "Synchronizing files. This may take a while..."
       environment:
         RSYNC_PASSWORD: "{{ rsync_password }}"
-      shell: "rsync -aPvvH --port 2222 {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
+      shell: "rsync {{ rsync_opts }} {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
       register: sync_output
       become: yes
 

--- a/3_run_rsync/vars/defaults.yml
+++ b/3_run_rsync/vars/defaults.yml
@@ -14,3 +14,7 @@ stunnel_cert_filepath: "./files/tls.crt"
 stunnel_key_filepath: "./files/tls.key"
 
 rsyncd_port:  22
+
+# Rsync default options
+rsync_opts: "-aPvvH --delete --port 2222"
+

--- a/3_run_rsync/vars/defaults.yml
+++ b/3_run_rsync/vars/defaults.yml
@@ -16,5 +16,5 @@ stunnel_key_filepath: "./files/tls.key"
 rsyncd_port:  22
 
 # Rsync default options
-rsync_opts: "-aPvvH --delete --port 2222"
+rsync_opts: "-aPvvH --delete"
 


### PR DESCRIPTION
- Allow user to specify custom rsync transfer options via rsync_opts variable
- Change default rsync_opts to include --delete which will remove files on destination that do not exist at the source
- Fixes #112 
