### PR TITLE
Making stunnel port configureable

### DIFF
--- a/3_run_rsync/README.md
+++ b/3_run_rsync/README.md
@@ -36,4 +36,8 @@ export KUBECONFIG="/path/to/destination_cluster_kubeconfig"
 ansible-playbook run-rsync.yml 
 ```
 
+By default, `rsync` accepts connections on port `2222` through `stunnel`. If the port is pre-occupied on your cluster, you can override it by using extra var `stunnel_rsync_port` : `ansible-playbook run-rsync.yml ... -e stunnel_rsync_port=<PORT> ...`.
+
+For all the default variables used, please check the [defaults.yml](./vars/defaults.yml) file.
+
 5. Refer to  [Step 7 - Run CAM in "no PV" mode](https://github.com/konveyor/pvc-migrate#7-run-cam-in-no-pvc-migration-mode) to complete the migration.

--- a/3_run_rsync/README.md
+++ b/3_run_rsync/README.md
@@ -36,7 +36,7 @@ export KUBECONFIG="/path/to/destination_cluster_kubeconfig"
 ansible-playbook run-rsync.yml 
 ```
 
-By default, `rsync` accepts connections on port `2222` through `stunnel`. If the port is pre-occupied on your cluster, you can override it by using extra var `stunnel_rsync_port` : `ansible-playbook run-rsync.yml ... -e stunnel_rsync_port=<PORT> ...`.
+By default, `rsync` accepts connections on port `2222` through `stunnel`. If the port is pre-occupied on your cluster, you can override it by using extra var `stunnel_port` : `ansible-playbook run-rsync.yml ... -e stunnel_port=<PORT> ...`.
 
 For all the default variables used, please check the [defaults.yml](./vars/defaults.yml) file.
 

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -63,6 +63,11 @@
     state: present
     definition: "{{ lookup('template', 'rsyncd.yml.j2') }}"
 
+- name: "Create stunnel configmap"
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'stunnel.yml.j2') }}"
+
 - debug:
     msg: "{{ lookup('template', 'pod.yml.j2') }}"
 
@@ -162,6 +167,11 @@
   k8s:
     state: absent
     definition: "{{ lookup('template', 'rsyncd.yml.j2') }}"
+
+- name: "Cleanup the configmap for stunnel"
+  k8s:
+    state: absent
+    definition: "{{ lookup('template', 'stunnel.yml.j2') }}"
 
 - name: "Printing failed / succeded pvcs"
   debug:

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -48,7 +48,7 @@
           client = yes
           syslog = no
           [rsync]
-          accept = {{ stunnel_rsync_port }}
+          accept = {{ stunnel_port }}
           CAFile = /etc/stunnel/tls.crt
           cert = /etc/stunnel/tls.crt
           connect = {{ mig_dest_service_url }}:443
@@ -131,7 +131,7 @@
     - name: "Synchronizing files. This may take a while..."
       environment:
         RSYNC_PASSWORD: "{{ rsync_password }}"
-      shell: "rsync {{ rsync_opts }} --port {{ stunnel_rsync_port }} {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
+      shell: "rsync {{ rsync_opts }} --port {{ stunnel_port }} {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
       register: sync_output
       become: yes
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -48,7 +48,7 @@
           client = yes
           syslog = no
           [rsync]
-          accept = 2222
+          accept = {{ stunnel_rsync_port }}
           CAFile = /etc/stunnel/tls.crt
           cert = /etc/stunnel/tls.crt
           connect = {{ mig_dest_service_url }}:443
@@ -131,7 +131,7 @@
     - name: "Synchronizing files. This may take a while..."
       environment:
         RSYNC_PASSWORD: "{{ rsync_password }}"
-      shell: "rsync {{ rsync_opts }} --port 2222 {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
+      shell: "rsync {{ rsync_opts }} --port {{ stunnel_rsync_port }} {{ mig_source_data_location }} rsync://{{ mig_dest_ssh_user }}@localhost/{{ pvc_vol_safe_name }}/"
       register: sync_output
       become: yes
 

--- a/3_run_rsync/templates/pod.yml.j2
+++ b/3_run_rsync/templates/pod.yml.j2
@@ -9,6 +9,9 @@ metadata:
     owner: pvc-migrate
 spec:
   volumes:
+  - name: pvc-migrate-stunnel-conf
+    configMap:
+      name: stunnel-conf
 {% for pvc in pvcs %}
   - name: {{ pvc.pvc_vol_safe_name }}
     persistentVolumeClaim:
@@ -56,8 +59,12 @@ spec:
   - name: stunnel
     imagePullPolicy: Always
     image: {{ transfer_pod_image }}
+    volumeMounts:
+    - mountPath: "/etc/stunnel/stunnel.conf"
+      name: pvc-migrate-stunnel-conf
+      subPath: stunnel.conf
     ports:
-      - containerPort: 2222
+      - containerPort: {{ stunnel_rsync_port }}
         name: stunnel
         protocol: TCP
     securityContext:

--- a/3_run_rsync/templates/pod.yml.j2
+++ b/3_run_rsync/templates/pod.yml.j2
@@ -64,7 +64,7 @@ spec:
       name: pvc-migrate-stunnel-conf
       subPath: stunnel.conf
     ports:
-      - containerPort: {{ stunnel_rsync_port }}
+      - containerPort: {{ stunnel_port }}
         name: stunnel
         protocol: TCP
     securityContext:

--- a/3_run_rsync/templates/stunnel.yml.j2
+++ b/3_run_rsync/templates/stunnel.yml.j2
@@ -16,8 +16,8 @@ data:
     sslVersion = TLSv1.2
 
     [rsync]
-    accept = {{ stunnel_rsync_port }}
-    connect = 22
+    accept = {{ stunnel_port }}
+    connect = {{ rsyncd_port }}
     key = /etc/stunnel/tls.key
     cert = /etc/stunnel/tls.crt
     TIMEOUTclose = 0

--- a/3_run_rsync/templates/stunnel.yml.j2
+++ b/3_run_rsync/templates/stunnel.yml.j2
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stunnel-conf
+  namespace: {{ pvc_namespace }}
+  labels:
+    app: {{ pod_name }}
+    purpose: stunnel-config
+    owner: pvc-migrate
+data:
+  stunnel.conf: |
+    foreground = yes
+    pid =
+    socket = l:TCP_NODELAY=1
+    socket = r:TCP_NODELAY=1
+    sslVersion = TLSv1.2
+
+    [rsync]
+    accept = {{ stunnel_rsync_port }}
+    connect = 22
+    key = /etc/stunnel/tls.key
+    cert = /etc/stunnel/tls.crt
+    TIMEOUTclose = 0

--- a/3_run_rsync/templates/svc.yml.j2
+++ b/3_run_rsync/templates/svc.yml.j2
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
   - name: stunnel
-    port: {{ stunnel_rsync_port }}
+    port: {{ stunnel_port }}
     protocol: TCP
-    targetPort: {{ stunnel_rsync_port }}
+    targetPort: {{ stunnel_port }}
   selector:
     app: {{ pod_name }}
     purpose: rsync
@@ -33,6 +33,6 @@ spec:
     kind: Service
     name: {{ svc_name }}
   port:
-    targetPort: {{ stunnel_rsync_port }}
+    targetPort: {{ stunnel_port }}
   tls:
     termination: passthrough

--- a/3_run_rsync/templates/svc.yml.j2
+++ b/3_run_rsync/templates/svc.yml.j2
@@ -10,9 +10,9 @@ metadata:
 spec:
   ports:
   - name: stunnel
-    port: 2222
+    port: {{ stunnel_rsync_port }}
     protocol: TCP
-    targetPort: 2222
+    targetPort: {{ stunnel_rsync_port }}
   selector:
     app: {{ pod_name }}
     purpose: rsync
@@ -33,6 +33,6 @@ spec:
     kind: Service
     name: {{ svc_name }}
   port:
-    targetPort: 2222
+    targetPort: {{ stunnel_rsync_port }}
   tls:
     termination: passthrough

--- a/3_run_rsync/vars/defaults.yml
+++ b/3_run_rsync/vars/defaults.yml
@@ -15,7 +15,7 @@ stunnel_key_filepath: "./files/tls.key"
 
 rsyncd_port:  22
 
-stunnel_rsync_port: 2222
+stunnel_port: 2222
 
 # Rsync default options
 rsync_opts: "-aPvvH --delete"

--- a/3_run_rsync/vars/defaults.yml
+++ b/3_run_rsync/vars/defaults.yml
@@ -15,6 +15,7 @@ stunnel_key_filepath: "./files/tls.key"
 
 rsyncd_port:  22
 
+stunnel_rsync_port: 2222
+
 # Rsync default options
 rsync_opts: "-aPvvH --delete"
-


### PR DESCRIPTION
Fixes #116 

The new approach uses ConfigMap for `stunnel` config to replace the default configuration at `/etc/stunnel/stunnel.conf` in the container. This allows users to replace the default `2222` port with the use of `stunnel_rsync_port` var, in case the default port is pre-occupied by other services. 


