### PR TITLE
Use core user by default for SSH

### DIFF
--- a/2_pvc_destination_gen/defaults/main.yml
+++ b/2_pvc_destination_gen/defaults/main.yml
@@ -1,0 +1,2 @@
+# SSH username for PV usage check
+ssh_username: core

--- a/2_pvc_destination_gen/tasks/adjust-pvs.yml
+++ b/2_pvc_destination_gen/tasks/adjust-pvs.yml
@@ -1,4 +1,6 @@
 - delegate_to: "{{ node_name }}"
+  vars:
+    ansible_user: "{{ ssh_username }}"
   block:
   - name: "Finding PVCs associated with {{ node_name }}"
     set_fact:


### PR DESCRIPTION
`core` is the default SSH user for CoreOS.
We would expect CoreOS for OpenShift installations