### PR TITLE
add variable and documentation for different provisioners

### DIFF
--- a/3_run_rsync/README.md
+++ b/3_run_rsync/README.md
@@ -27,7 +27,19 @@ mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transf
 
 # Wait for transfer pod service ELB deletion to complete before proceeding to next PVC
 wait_for_finalizer: false
+
+provisioner: "kubernetes.io/glusterfs"
 ```
+
+Replace the dynamicProvisionerName by picking one from the supported options
+in [run-rsync.yml.example](./vars/run-rsync.yml.example).
+
+_*Note:*_ pvc-migrate assumes that all the pvc's in your namespaces are
+provisioned by a single provisioner. Please take a look at 
+[issue 152](https://github.com/konveyor/pvc-migrate/issues/152) for more
+ context on the problem.
+
+
 
 4. Run Stage 3 playbook while KUBECONFIG is set for connection to **destination cluster**
 ```

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -11,7 +11,7 @@
 
 - set_fact:
     mig_source_data_base_location: "/var/lib/origin/openshift.local.volumes"
-    mig_source_data_location_k8s_mount: "kubernetes.io~glusterfs"
+    mig_source_data_location_k8s_mount: "{{ provisioner | replace('/', '~') }}"
 
 - set_fact:
     mig_dest_service_url: "{{ rsync_route.resources[0].spec.host }}"

--- a/3_run_rsync/vars/run-rsync.yml.example
+++ b/3_run_rsync/vars/run-rsync.yml.example
@@ -10,3 +10,32 @@ mig_dest_ssh_private_key: "" # path to private key used for SSH auth into transf
 
 # [DEPRECATED] Wait for transfer pod service ELB deletion to complete before proceeding to next PVC.
 wait_for_finalizer: false
+
+# plugins supported by kubernetes
+# "kubernetes.io/aws-ebs"
+# "kubernetes.io/azure-file"
+# "kubernetes.io/azure-disk"
+# "kubernetes.io/cephfs"
+# "kubernetes.io/cinder"
+# "kubernetes.io/csi"
+# "kubernetes.io/fc"
+# "kubernetes.io/flexvolume"
+# "kubernetes.io/flocker"
+# "kubernetes.io/gce-pd"
+# "kubernetes.io/host-path"
+# "kubernetes.io/iscsi"
+# "kubernetes.io/local-volume"
+# "kubernetes.io/nfs"
+# "kubernetes.io/portworx-volume"
+# "kubernetes.io/quobyte"
+# "kubernetes.io/rbd"
+# "kubernetes.io/scaleio"
+# "kubernetes.io/storageos"
+# "kubernetes.io/vsphere-volume"
+
+# This above list is curated from https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+# the values are cross checked from https://github.com/kubernetes/kubernetes/tree/master/pkg/volume
+# example of a plugin name with its path https://github.com/kubernetes/kubernetes/blob/a744bddbf497ab718a40bee1c730e7e848e471ed/pkg/volume/awsebs/aws_ebs.go#L59
+# more context https://github.com/kubernetes/kubernetes/blob/a744bddbf497ab718a40bee1c730e7e848e471ed/pkg/volume/awsebs/aws_ebs.go#L64
+
+provisioner: "kubernetes.io/glusterfs"


### PR DESCRIPTION
This PR defaults the dynamicProvisionerName to glusterfs, 
but also adds documentation on other supported storage plugin options
in kubernetes. Users with different storage providers and change
the default in vars file and use pvc-migrate