### PR TITLE
run rsync on sshd via node port

### DIFF
--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -79,8 +79,8 @@
               and svc.resources[0].spec is defined
               and svc.resources[0].spec.ports is defined
               and (svc.resources[0].spec.ports | length) == 1
-              and svc.resources[0].spec.ports.[0].name == 'ssh'
-              and svc.resources[0].spec.ports.[0].nodePort is defined"
+              and svc.resources[0].spec.ports[0].name == 'ssh'
+              and svc.resources[0].spec.ports[0].nodePort is defined"
 
   retries: "{{ transfer_svc_wait_retries }}"
   delay: 3

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -76,11 +76,12 @@
     namespace: "{{ pvc_namespace }}"
   register: svc
   until: " svc.resources is defined
-            and svc.resources[0].status is defined
-            and svc.resources[0].status.loadBalancer is defined
-            and svc.resources[0].status.loadBalancer.ingress is defined
-            and (svc.resources[0].status.loadBalancer.ingress | length) == 1
-            and svc.resources[0].status.loadBalancer.ingress[0].hostname is defined"
+              and svc.resources[0].spec is defined
+              and svc.resources[0].spec.ports is defined
+              and (svc.resources[0].spec.ports | length) == 1
+              and svc.resources[0].spec.ports.[0].name == 'ssh'
+              and svc.resources[0].spec.ports.[0].nodePort is defined"
+
   retries: "{{ transfer_svc_wait_retries }}"
   delay: 3
 

--- a/3_run_rsync/tasks/create-pod-service.yml
+++ b/3_run_rsync/tasks/create-pod-service.yml
@@ -85,6 +85,18 @@
   retries: "{{ transfer_svc_wait_retries }}"
   delay: 3
 
+- name: "Get the destination node"
+  k8s_info:
+    api_version: v1
+    kind: node
+    name: "{{ pod.resources[0].spec.nodeName }}"
+  register: dest_node
+
+- set_fact:
+#    if the tasks fails here, chances are this node does not have the right status.
+#      Please either replace the node or fix the status to make pvc-migrate work
+    dest_ip_address: "{{ dest_node.resources[0].status | json_query('addresses[? type==`InternalIP`].address') }}"
+
 - set_fact:
     failed_pvcs: []
     successful_pvcs: []

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -14,7 +14,7 @@
     mig_source_data_location_k8s_mount: "kubernetes.io~glusterfs"
 
 - set_fact:
-    mig_dest_service_url: "{{ pod.resources[0].spec.nodeName }}"
+    mig_dest_service_url: "{{ dest_ip_address }}"
     rsync_dest_port: "{{ svc.resources[0].spec.ports[0].nodePort }}"
     mig_dest_data_location: "/mnt/{{ pvc_ns }}/{{ pvc_vol_safe_name }}"
     mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ volume_name }}/"
@@ -39,13 +39,6 @@
       dest: "{{ mig_dest_ssh_key_remote_location }}"
       mode: 0600
     become: yes
-
-  - name: "Wait for dns"
-    shell: "nslookup {{ mig_dest_service_url }}"
-    register: dig_output
-    until: dig_output.rc == 0
-    retries: 100
-    delay: 3
 
   - name: "Ensure directory exists on the source"
     stat:

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -14,7 +14,8 @@
     mig_source_data_location_k8s_mount: "kubernetes.io~glusterfs"
 
 - set_fact:
-    mig_dest_service_url: "{{ svc.resources[0].status.loadBalancer.ingress[0].hostname }}"
+    mig_dest_service_url: "{{ pod.spec.nodeName }}"
+    rsync_dest_port: "{{ svc.resources[0].spec.ports.[0].nodePort }}"
     mig_dest_data_location: "/mnt/{{ pvc_ns }}/{{ pvc_vol_safe_name }}"
     mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ volume_name }}/"
     mig_source_host: "{{ node_name }}"
@@ -59,7 +60,7 @@
         Skipping to the next PV...
 
   - name: "Synchronizing files. This may take a while..."
-    shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p 2222 -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
+    shell: "rsync -aPvvH {{ mig_source_data_location }} -e 'ssh -p {{ rsync_dest_port }} -o StrictHostKeyChecking=no -i {{ mig_dest_ssh_key_remote_location }}' {{ mig_dest_ssh_user }}@{{ mig_dest_service_url }}:{{ mig_dest_data_location }}"
     register: sync_output
     become: yes
 

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -15,7 +15,7 @@
 
 - set_fact:
     mig_dest_service_url: "{{ pod.spec.nodeName }}"
-    rsync_dest_port: "{{ svc.resources[0].spec.ports.[0].nodePort }}"
+    rsync_dest_port: "{{ svc.resources[0].spec.ports[0].nodePort }}"
     mig_dest_data_location: "/mnt/{{ pvc_ns }}/{{ pvc_vol_safe_name }}"
     mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ volume_name }}/"
     mig_source_host: "{{ node_name }}"

--- a/3_run_rsync/tasks/rsync.yml
+++ b/3_run_rsync/tasks/rsync.yml
@@ -14,7 +14,7 @@
     mig_source_data_location_k8s_mount: "kubernetes.io~glusterfs"
 
 - set_fact:
-    mig_dest_service_url: "{{ pod.spec.nodeName }}"
+    mig_dest_service_url: "{{ pod.resources[0].spec.nodeName }}"
     rsync_dest_port: "{{ svc.resources[0].spec.ports[0].nodePort }}"
     mig_dest_data_location: "/mnt/{{ pvc_ns }}/{{ pvc_vol_safe_name }}"
     mig_source_data_location: "{{ mig_source_data_base_location }}/pods/{{ bound_pod_uid }}/volumes/{{ mig_source_data_location_k8s_mount }}/{{ volume_name }}/"

--- a/3_run_rsync/templates/svc.yml.j2
+++ b/3_run_rsync/templates/svc.yml.j2
@@ -17,4 +17,4 @@ spec:
     app: {{ pod_name }}
     purpose: rsync
     owner: pvc-migrate
-  type: LoadBalancer
+  type: NodePort


### PR DESCRIPTION
This PR 
- changes the service from an external load balancer to node port
- removes the DNS lookup on external load balancer dns name
- adds lookup to the node and uses the internal IP address as the destination url