### PR TITLE
Remove rsyncd logs and replace with /stdout

### DIFF
--- a/3_run_rsync/templates/pod.yml.j2
+++ b/3_run_rsync/templates/pod.yml.j2
@@ -12,8 +12,6 @@ spec:
   - name: pvc-migrate-stunnel-conf
     configMap:
       name: "{{ stunnel_config }}"
-  - name: rsyncd-log
-    emptyDir: {}
 {% for pvc in pvcs %}
   - name: "{{ pvc.pvc_vol_safe_name }}"
     persistentVolumeClaim:
@@ -23,19 +21,6 @@ spec:
     configMap:
       name: "{{ rsyncd_config }}"
   containers:
-  - name: rsyncd-logs
-    image: "{{ transfer_pod_image }}"
-    command:
-    - bash
-    - -c
-    - tail -f  {{ rsyncd_log_filepath }}
-    volumeMounts:
-    - mountPath: /var/log/pvc-migrate
-      name: rsyncd-log
-    securityContext:
-      privileged: true
-      readOnlyRootFilesystem: false
-      runAsUser: 0
   - name: rsyncd
     resources:
       limits:
@@ -55,8 +40,6 @@ spec:
       name: rsyncd
       protocol: TCP
     volumeMounts:
-    - mountPath: {{ rsyncd_log_filepath }}
-      name: rsyncd-log
 {% for pvc in pvcs %}
     - mountPath: "/mnt/{{ pvc_namespace }}/{{ pvc.pvc_vol_safe_name }}"
       name: "{{ pvc.pvc_vol_safe_name }}"

--- a/3_run_rsync/templates/rsyncd.yml.j2
+++ b/3_run_rsync/templates/rsyncd.yml.j2
@@ -12,7 +12,7 @@ data:
     syslog facility = local7
     read only = no
     list = yes
-    log file = {{ rsyncd_log_filepath }}
+    log file = /dev/stdout
     max verbosity = 4
     auth users = {{ mig_dest_ssh_user|string }}
     secrets file = /etc/rsyncd.secrets

--- a/3_run_rsync/vars/defaults.yml
+++ b/3_run_rsync/vars/defaults.yml
@@ -19,7 +19,6 @@ stunnel_port: 2222
 
 # Rsync default options
 rsync_opts: "-aPvvHh --delete"
-rsyncd_log_filepath: "/var/log/pvc-migrate/rsyncd.log"
 
 route_host: ""
 route_timeout_seconds: 600


### PR DESCRIPTION
This PR removes Rsync daemon log file and volume and replaces it with stdout instead.